### PR TITLE
PayPal-OTP-Required

### DIFF
--- a/src/general.js
+++ b/src/general.js
@@ -118,6 +118,10 @@ const errors = {
   SINPE_REF_REQUIRED: {
     code: 'general-26',
     message: 'Sinpe Reference is required'
+  },
+  OTP_NOT_DEFINED: {
+    code: 'general-27',
+    message: 'OTP is not defined'
   }
 }
 


### PR DESCRIPTION
Se ingresa error en General de OTP no definido, esto para validar error en PayPal de recargas realizadas sin tener OTP definido.

