### PR TITLE
WinkError-EnvelopesAmount

### DIFF
--- a/dist/envelopes.js
+++ b/dist/envelopes.js
@@ -19,6 +19,10 @@ const errors = {
   SAVINGS_BLOCKED: {
     code: 'envelopes-4',
     message: 'You are not allowed to reload funds'
+  },
+  PROJECTED_AMOUNT_EXCEEDED: {
+    code: 'envelopes-5',
+    message: 'Amount exceeds projected amount'
   }
 };
 

--- a/src/envelopes.js
+++ b/src/envelopes.js
@@ -14,6 +14,10 @@ const errors = {
   SAVINGS_BLOCKED: {
     code: 'envelopes-4',
     message: 'You are not allowed to reload funds'
+  },
+  PROJECTED_AMOUNT_EXCEEDED: {
+    code: 'envelopes-5',
+    message: 'Amount exceeds projected amount'
   }
 }
 


### PR DESCRIPTION
Se crea error para agregar monto a sobre recurrente validar que el monto a agregar no supere el monto proyectado del sobre.