### PR TITLE
PDL-8049: Add error for exceeding daily Sinpe Movil limit

### DIFF
--- a/dist/sendMoney.js
+++ b/dist/sendMoney.js
@@ -44,7 +44,7 @@ const errors = {
     code: 'sendMoney-10',
     message: 'It was not possible to register the transaction because is a self transaction'
   },
-  SINPE_MOVIL_DAYLI_LIMIT_EXCEEDED: {
+  SINPE_MOVIL_DAILY_LIMIT_EXCEEDED: {
     code: 'sendMoney-11',
     message: 'The amount exceeds the daily sinpe movil limit'
   }

--- a/dist/sendMoney.js
+++ b/dist/sendMoney.js
@@ -43,6 +43,10 @@ const errors = {
   SELF_TRANSFER_NOT_ALLOWED: {
     code: 'sendMoney-10',
     message: 'It was not possible to register the transaction because is a self transaction'
+  },
+  SINPE_MOVIL_DAYLI_LIMIT_EXCEEDED: {
+    code: 'sendMoney-11',
+    message: 'The amount exceeds the daily sinpe movil limit'
   }
 };
 

--- a/src/sendMoney.js
+++ b/src/sendMoney.js
@@ -38,7 +38,7 @@ const errors = {
   },
   SELF_TRANSFER_NOT_ALLOWED: {
     code: 'sendMoney-10',
-    message:  'It was not possible to register the transaction because is a self transaction'
+    message: 'It was not possible to register the transaction because is a self transaction'
   },
   SINPE_MOVIL_DAYLI_LIMIT_EXCEEDED: {
     code: 'sendMoney-11',

--- a/src/sendMoney.js
+++ b/src/sendMoney.js
@@ -40,7 +40,7 @@ const errors = {
     code: 'sendMoney-10',
     message: 'It was not possible to register the transaction because is a self transaction'
   },
-  SINPE_MOVIL_DAYLI_LIMIT_EXCEEDED: {
+  SINPE_MOVIL_DAILY_LIMIT_EXCEEDED: {
     code: 'sendMoney-11',
     message: 'The amount exceeds the daily sinpe movil limit'
   }

--- a/src/sendMoney.js
+++ b/src/sendMoney.js
@@ -38,7 +38,11 @@ const errors = {
   },
   SELF_TRANSFER_NOT_ALLOWED: {
     code: 'sendMoney-10',
-    message: 'It was not possible to register the transaction because is a self transaction'
+    message:  'It was not possible to register the transaction because is a self transaction'
+  },
+  SINPE_MOVIL_DAYLI_LIMIT_EXCEEDED: {
+    code: 'sendMoney-11',
+    message: 'The amount exceeds the daily sinpe movil limit'
   }
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `src/sendMoney.js` file. The change adds a new error type to the `errors` object.

* [`src/sendMoney.js`](diffhunk://#diff-cffae4b972c7b9a933aa11279d78bdd979ad06b2db37faaee5b511e37200c296R42-R45): Added `SINPE_MOVIL_DAILY_LIMIT_EXCEEDED` error type to handle cases where the transaction amount exceeds the daily Sinpe Movil limit.
* 
https://holawink.atlassian.net/browse/PDL-8049