### PR TITLE
subtask/PDL-9489-create-new-error-operation-fraud-verification-rejected

### DIFF
--- a/dist/general.js
+++ b/dist/general.js
@@ -145,6 +145,10 @@ const errors = {
     code: 'Actualiza la APP para que podas continuar con tu experiencia Wink',
     description: 'Route or resource not found',
     httpStatus: 404
+  },
+  OPERATION_FRAUD_VERIFICATION_REJECTED: {
+    code: 'general-30',
+    message: 'Operation rejected'
   }
 };
 

--- a/src/general.js
+++ b/src/general.js
@@ -143,6 +143,10 @@ const errors = {
     code: 'Actualiza la APP para que podas continuar con tu experiencia Wink',
     description: 'Route or resource not found',
     httpStatus: 404
+  },
+  OPERATION_FRAUD_VERIFICATION_REJECTED: {
+    code: 'general-30',
+    message: 'Operation rejected'
   }
 }
 


### PR DESCRIPTION
PDL-9489

This pull request includes a small addition to the `errors` object in the `src/general.js` file. The change introduces a new error type for operation fraud verification rejection.

* [`src/general.js`](diffhunk://#diff-8358c18541205334b2ee205db937091c36a22499b1dbfa15bfb2f87e95a1a017R146-R149): Added `OPERATION_FRAUD_VERIFICATION_REJECTED` error type with code `general-30` and message 'Operation rejected'.